### PR TITLE
Small updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,17 @@ homepage = "https://github.com/portocodes/tico"
 repository = "https://github.com/portocodes/tico"
 readme = "README.md"
 license = "MIT"
+edition = "2021"
+
+[profile.release]
+lto = true
+codegen-units = 1
+strip = true
+opt-level = 3
 
 [[bin]]
 name = "tico"
 doc = false
 
 [dependencies]
-dirs = "2.0.2"
+dirs = "5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ extern crate dirs;
 /// ```
 pub fn tico(path: &str, home_dir: Option<&str>) -> String {
     let tico = match home_dir {
-        Some(dir) => path.replacen(&dir, "~", 1),
+        Some(dir) => path.replacen(dir, "~", 1),
         None => path.to_owned(),
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,6 @@ fn main() {
     let home_dir_str = home_dir.to_str();
 
     std::io::stdout()
-        .write(tico::tico(&path, home_dir_str).as_bytes())
+        .write_all(tico::tico(&path, home_dir_str).as_bytes())
         .unwrap();
 }


### PR DESCRIPTION
This implements two suggestions by clippy, one warning in `lib.rs`[^1] and one error in `main.rs`[^2].

I took the liberty to update Cargo.toml as well.

[^1]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args
[^2]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_io_amount